### PR TITLE
修复分组复制会导致两个分组指向同一个变量的问题 fix #24

### DIFF
--- a/src/S7SvrSim/ViewModels/Signals/SignalEditObj.cs
+++ b/src/S7SvrSim/ViewModels/Signals/SignalEditObj.cs
@@ -179,6 +179,11 @@ namespace S7SvrSim.ViewModels
 
         private void OnOtherChanged(Type value)
         {
+            if (value == null)
+            {
+                return;
+            }
+
             var newVal = (SignalBase)Activator.CreateInstance(value);
 
             if (Value != null)

--- a/src/S7SvrSim/ViewModels/Signals/SignalsCollection.cs
+++ b/src/S7SvrSim/ViewModels/Signals/SignalsCollection.cs
@@ -212,7 +212,11 @@ namespace S7SvrSim.ViewModels.Signals
             var renameResult = await GetNewGroupName("Rename Group", sg.Name, true);
             if (renameResult.IsCancel || string.IsNullOrEmpty(renameResult.Result)) return;
 
-            var newSg = new SignalEditGroup(renameResult.Result, sg.Signals);
+            // 对组内每个信号进行深拷贝
+            var copiedSignals = sg.Signals.Select(s => {
+                return new SignalEditObj(s.SignalType, s.Value.Name, s.Value.FormatAddress, s.Value.Remark);
+            });
+            var newSg = new SignalEditGroup(renameResult.Result, copiedSignals);
             SignalGroups.Insert(SignalGroups.IndexOf(sg) + 1, newSg);
         }
         #endregion


### PR DESCRIPTION
- 在 SignalsCollection.CopyGroup 函数中没有对 SignalEditObj 进行深拷贝，导致监看界面复制出来的分组，修改地址后原来的地址也会修改